### PR TITLE
JBDS-4687 rebrand JBoss Fuse / Fuse Tools as Red Hat Fuse / Red Hat Fuse Tooling

### DIFF
--- a/features/com.jboss.devstudio.fuse.feature/feature.properties
+++ b/features/com.jboss.devstudio.fuse.feature/feature.properties
@@ -15,13 +15,13 @@
 # This file should be translated.
 
 # "featureName" property - name of the feature
-featureName=Red Hat JBoss Fuse Tools
+featureName=Red Hat Fuse Tooling
 
 # "providerName" property - name of the company that provides the feature
 providerName=JBoss by Red Hat
 
 # "description" property - description of the feature
-description=This feature contains all the features of JBoss Fuse Tools.
+description=This feature contains all the features of Red Hat Fuse Tooling.
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=Copyright (c) 2017-2018 Red Hat, Inc. and others.\nAll rights reserved. This program and the accompanying materials\n 

--- a/installer/src/config/resources/AdditionalFeaturesSpec.json
+++ b/installer/src/config/resources/AdditionalFeaturesSpec.json
@@ -2,7 +2,7 @@
 	{
 		"id"         :"com.jboss.devstudio.fuse.feature.feature.group",
 		"path"       :"devstudio",
-		"label"      :"JBoss Fuse Tooling",
+		"label"      :"Red Hat Fuse Tooling",
 		"description":"",
 		"selected"   :"false"
 	}

--- a/installer/src/panels/com/jboss/devstudio/core/installer/UpdatePacksPanel.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/UpdatePacksPanel.java
@@ -37,7 +37,7 @@ public class UpdatePacksPanel extends IzPanel{
 		String installIUs = idata.getVariable("INSTALL_IUS");
 		if (installIUs != null) {
 			if (installIUs.contains("devstudio.fuse"))
-				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat JBoss Fuse Tooling<br>");
+				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat Red Hat Fuse Tooling<br>");
 			if (installIUs.contains("integration-stack.bpr"))
 				additionalSummaryInfo = additionalSummaryInfo.concat("Red Hat JBoss Business Process and Rules Development<br>");
 			if (installIUs.contains("integration-stack.ds"))

--- a/installer/src/panels/com/jboss/devstudio/core/installer/bean/RuntimeServer.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/bean/RuntimeServer.java
@@ -15,8 +15,8 @@ package com.jboss.devstudio.core.installer.bean;
  * A runtime server bean is a set of methods for describing and manipulating supplemental runtime
  * servers from json files (e.g.):
  	{
-		"label":"JBoss Fuse Server",
-		"description":"Fuse Server/ Runtime",
+		"label":"Red Hat Fuse Server",
+		"description":"Red Hat Fuse Server/ Runtime",
 		"selected":"true",
 		"path":"devstudio-is/runtime/jboss-fuse-full-6.3.0.redhat-077.zip"
 		"size":"804978918"

--- a/site/category.xml
+++ b/site/category.xml
@@ -259,27 +259,27 @@
   </feature>
 
   <feature id="org.fusesource.ide.core.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <feature id="org.fusesource.ide.camel.editor.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <feature id="org.fusesource.ide.jmx.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <feature id="org.fusesource.ide.server.extensions.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <feature id="org.fusesource.ide.syndesis.extension.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <feature id="org.jboss.tools.fuse.transformation.feature">
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
 
   <!-- JBIDE-24897 not ready yet <feature id="com.redhat.fabric8analytics.lsp.eclipse.feature">
@@ -367,7 +367,7 @@
   <feature id="com.jboss.devstudio.fuse.feature">
     <category name="BringYourOwnEclipse" />
     <category name="CoreTools" />
-    <category name="FuseTools" />
+    <category name="FuseTooling" />
   </feature>
   <feature id="org.eclipse.egit"/>
   <feature id="org.eclipse.jgit"/>
@@ -524,8 +524,8 @@
     <description>Tools for Cloud and Container Development.</description>
   </category-def>
 
-  <category-def name="FuseTools" label="JBoss Fuse Tools">
-    <description>Tools to allow you to create Apache Camel routes in a graphical editor, launch them locally and deploy them to runtimes like Apache Karaf, Fabric8 and JBoss Fuse.</description>
+  <category-def name="FuseTooling" label="Red Hat Fuse Tooling">
+    <description>Tools to allow you to create Apache Camel routes in a graphical editor, launch them locally and deploy them to runtimes like Apache Karaf, Fabric8 and Red Hat Fuse.</description>
   </category-def>
 
 <!--


### PR DESCRIPTION
JBDS-4687 rebrand JBoss Fuse / Fuse Tools as Red Hat Fuse / Red Hat Fuse Tooling

Signed-off-by: nickboldt <nboldt@redhat.com>